### PR TITLE
Translate page title and section names to Portuguese

### DIFF
--- a/Scriptures/index.html
+++ b/Scriptures/index.html
@@ -1,21 +1,23 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="pt">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Scriptures</title>
+    <title>Escrituras</title>
 </head>
 <body>
-<h1>Ancient Christian Writtings (Escrituras Cristãs Antigas)</h1>
+<h1>Antigas Escrituras Cristãs</h1>
 <ul>
-  <li>New Testament (Novo Testamento)</li>
-  <li>Apocrypha (Apócrifos)</li>
+  <li>Novo Testamento</li>
+  <li>Apócrifos</li>
   <ul>
-    <li>Gospels (Evangelhos)</li>
-    <li>Apostolic Acts (Atos Apostólicos):</li>
+    <li>Evangelhos</li>
+    <li>Atos Apostólicos</li>
       <ul>
-        <li><a href="Acts_of_Paul/0_intro.html">Acts of Paul (Estimated Range of Dating: 150-200 a.C.)</a></li>
-        <li><a href="Atos_de_Paulo/0_intro.html">Atos de Paulo (Faixa de Datação Estimada: 150-200 d.C.)</a> tradução em: português.</li>
-      </ul></ul></ul>
+        <li><a href="Atos_de_Paulo/0_intro.html">Atos de Paulo (Faixa de Datação Estimada: 150-200 d.C.)</a></li>
+      </ul>
+    <li><a href="didache.html">Didache (Faixa estimada de datação: 50-120 d.C.)</a></li>
+  </ul>
+</ul>
 </body>
 </html>

--- a/Scriptures/indice.html
+++ b/Scriptures/indice.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Scriptures</title>
+</head>
+<body>
+<h1>Ancient Christian Writtings (Escrituras Cristãs Antigas)</h1>
+<ul>
+  <li>New Testament (Novo Testamento)</li>
+  <li>Apocrypha (Apócrifos)</li>
+  <ul>
+    <li>Gospels (Evangelhos)</li>
+    <li>Apostolic Acts (Atos Apostólicos):</li>
+      <ul>
+        <li><a href="Acts_of_Paul/0_intro.html">Acts of Paul (Estimated Range of Dating: 150-200 a.C.)</a></li>
+        <li><a href="Atos_de_Paulo/0_intro.html">Atos de Paulo (Faixa de Datação Estimada: 150-200 d.C.)</a> tradução em: português.</li>
+      </ul>
+    <li><a href="didache.html">Didache</a></li></ul></ul>
+</body>
+</html>


### PR DESCRIPTION
This pull request updates the `index.html` file to translate the page title and section names to Portuguese. The changes include updating the HTML lang attribute to "pt" and translating the titles and names of various sections. This update improves the localization of the webpage for Portuguese-speaking users.